### PR TITLE
Use Builtin Gradle Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     ext {
         junit_version = '5.5.1'
-        junit_platform_version = '1.2.0'
         kotlin_version = '1.3.31'
         dokka_version = '0.9.18'
         bintray_version = '1.8.4'
@@ -80,10 +79,13 @@ configure(pluginProjects) {
             //e.g. set the version to a different version than the default
             //toolVersion = '0.8.3'
         }
+    }
 
-        //delegates to the junitPlatform extension (just for your convenience, everything in one place)
-        junitPlatform {
-            reportsDir = file("${buildDir}/reports/junit")
+    test {
+        reports {
+            html {
+                destination = file("${buildDir}/reports/junit")
+            }
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 buildscript {
     rootProject.name = 'tutteli-gradle'
-    gradle.ext.version = '0.27.3'
+    gradle.ext.version = '0.28.0-SNAPSHOT'
     gradle.ext.previous_version = '0.26.1'
 
     gradle.ext.repo = "${rootProject.projectDir}/repo"

--- a/test-utils/src/main/groovy/ch/tutteli/gradle/test/SettingsExtension.groovy
+++ b/test-utils/src/main/groovy/ch/tutteli/gradle/test/SettingsExtension.groovy
@@ -33,6 +33,7 @@ class SettingsExtensionObject {
 
     String buildscriptWithKotlin(String kotlinVersion) {
         return """
+        import org.gradle.api.tasks.testing.logging.TestLogEvent
         buildscript {
             repositories { maven { url "https://plugins.gradle.org/m2/" } }
             dependencies {
@@ -41,6 +42,20 @@ class SettingsExtensionObject {
             }
         }
         """
+    }
+
+
+    String configureTestLogging() {
+        return """
+            tasks.withType(Test) {
+                testLogging {
+                    events TestLogEvent.FAILED,
+                        TestLogEvent.PASSED,
+                        TestLogEvent.SKIPPED,
+                        TestLogEvent.STANDARD_OUT
+                }
+            }
+            """
     }
 }
 

--- a/tutteli-gradle-junitjacoco/build.gradle
+++ b/tutteli-gradle-junitjacoco/build.gradle
@@ -3,11 +3,7 @@ buildscript {
         plugin_id = 'ch.tutteli.junitjacoco'
         plugin_class = 'ch.tutteli.gradle.junitjacoco.JunitJacocoPlugin'
         plugin_name = 'Tutteli Jacoco Plugin'
-        plugin_description = 'Applies the junit5 platform plugin and binds jacoco to it.'
+        plugin_description = 'Sets up JaCoCo for the JUnit 5 Platform'
         plugin_tags = ['jacoco', 'junit']
     }
-}
-
-dependencies {
-    implementation "org.junit.platform:junit-platform-gradle-plugin:$junit_platform_version"
 }

--- a/tutteli-gradle-junitjacoco/src/main/groovy/ch/tutteli/gradle/junitjacoco/JunitJacocoPlugin.groovy
+++ b/tutteli-gradle-junitjacoco/src/main/groovy/ch/tutteli/gradle/junitjacoco/JunitJacocoPlugin.groovy
@@ -4,35 +4,32 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.testing.Test
 import org.gradle.testing.jacoco.plugins.JacocoPlugin
-import org.junit.platform.gradle.plugin.JUnitPlatformPlugin
 
 class JunitJacocoPlugin implements Plugin<Project> {
     private static final Logger LOGGER = Logging.getLogger(JunitJacocoPlugin.class)
 
-    static final String ARG_REPORTS_DIR = '--reports-dir'
-    static final String JUNIT_TASK_NAME = 'junitPlatformTest'
     static final String EXTENSION_NAME = 'junitjacoco'
-    static final String REPORT_TASK_NAME = 'junitPlatformJacocoReport'
+    static final String TEST_TASK_NAME = 'test'
+    static final String JACOCO_TASK_NAME = 'jacocoTestReport'
 
     @Override
     void apply(Project project) {
-        project.getPluginManager().apply(JUnitPlatformPlugin)
-        project.getPluginManager().apply(JacocoPlugin)
-        def junitPlatformTestTask = project.tasks.getByName(JUNIT_TASK_NAME)
-        def extension = project.extensions.create(EXTENSION_NAME, JunitJacocoPluginExtension, project, junitPlatformTestTask)
+        project.pluginManager.apply(JavaPlugin)
+        project.pluginManager.apply(JacocoPlugin)
+        def extension = project.extensions.create(EXTENSION_NAME, JunitJacocoPluginExtension, project)
+        project.tasks.getByName(TEST_TASK_NAME) { Test test ->
+            test.useJUnitPlatform()
+        }
 
         project.afterEvaluate {
             def keepItEnabled = extension.enableJunitReport.get()
             LOGGER.debug("enable junit report: ${keepItEnabled}")
             if (!keepItEnabled) {
-                List args = junitPlatformTestTask.args
-                def reportIndex = args.findIndexOf { it == ARG_REPORTS_DIR }
-                if (reportIndex != -1) {
-                    def keep = (0..(args.size() - 1)) - [reportIndex, reportIndex + 1]
-                    junitPlatformTestTask.args = args[keep]
-                } else {
-                    LOGGER.warn("junit report was already disabled")
+                project.tasks.getByName(TEST_TASK_NAME) { Test test ->
+                    test.reports.junitXml.enabled = false
                 }
             }
         }

--- a/tutteli-gradle-junitjacoco/src/main/groovy/ch/tutteli/gradle/junitjacoco/JunitJacocoPluginExtension.groovy
+++ b/tutteli-gradle-junitjacoco/src/main/groovy/ch/tutteli/gradle/junitjacoco/JunitJacocoPluginExtension.groovy
@@ -2,25 +2,23 @@ package ch.tutteli.gradle.junitjacoco
 
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.provider.Property
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import org.gradle.testing.jacoco.tasks.JacocoReport
-import org.junit.platform.gradle.plugin.JUnitPlatformExtension
 
 class JunitJacocoPluginExtension {
-    private Task junitPlatformTestTask
     private JacocoPluginExtension jacocoPluginExtension
     private JacocoReport jacocoReportTask
-    private JUnitPlatformExtension junitPlatformExtension
 
+    /**
+     * @deprecated Use the gradle API instead: test { reports { junitXml { enabled = false }}}
+     */
+    @Deprecated(/*since = "0.28.0"*/)
     Property<Boolean> enableJunitReport
 
-    JunitJacocoPluginExtension(Project project, Task junitPlatformTestTask) {
-        this.junitPlatformTestTask = junitPlatformTestTask
+    JunitJacocoPluginExtension(Project project) {
         this.jacocoPluginExtension = project.extensions.getByType(JacocoPluginExtension)
-        this.jacocoReportTask = project.task(type: JacocoReport, JunitJacocoPlugin.REPORT_TASK_NAME) as JacocoReport
-        this.junitPlatformExtension = project.extensions.getByType(JUnitPlatformExtension)
+        this.jacocoReportTask = project.tasks.getByName(JunitJacocoPlugin.JACOCO_TASK_NAME) as JacocoReport
         this.enableJunitReport = project.objects.property(Boolean)
         this.enableJunitReport.set(false)
         project.check.dependsOn jacocoReportTask
@@ -29,16 +27,12 @@ class JunitJacocoPluginExtension {
 
     private void defaultConfig() {
 
-        //necessary that it is accessible within the closure without the need of a public getter
-        def junitTask = junitPlatformTestTask
         jacoco {
             toolVersion = '0.8.3'
-            applyTo junitTask
         }
 
-        jacocoReport {
+        jacocoReportTask.configure {
             sourceSets project.sourceSets.main
-            executionData junitTask
             reports {
                 csv.enabled = false
                 csv.destination project.file("${project.jacoco.reportsDir}/report.csv")
@@ -54,11 +48,11 @@ class JunitJacocoPluginExtension {
         configure.execute(jacocoPluginExtension)
     }
 
+    /**
+     * @deprecated Use the gradle API instead: jacocoTestReport {...}
+     */
+    @Deprecated(/*since = "0.28.0"*/)
     void jacocoReport(Action<JacocoReport> configure) {
         configure.execute(jacocoReportTask)
-    }
-
-    void junitPlatform(Action<JUnitPlatformExtension> configure) {
-        configure.execute(junitPlatformExtension)
     }
 }

--- a/tutteli-gradle-junitjacoco/src/test/groovy/ch/tutteli/gradle/junitjacoco/JunitJacocoPluginSmokeTest.groovy
+++ b/tutteli-gradle-junitjacoco/src/test/groovy/ch/tutteli/gradle/junitjacoco/JunitJacocoPluginSmokeTest.groovy
@@ -2,9 +2,11 @@ package ch.tutteli.gradle.junitjacoco
 
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.junit.jupiter.api.Test
 
-import static ch.tutteli.gradle.junitjacoco.JunitJacocoPlugin.*
+import static ch.tutteli.gradle.junitjacoco.JunitJacocoPlugin.getEXTENSION_NAME
+import static ch.tutteli.gradle.junitjacoco.JunitJacocoPlugin.getJACOCO_TASK_NAME
 import static org.junit.jupiter.api.Assertions.*
 
 class JunitJacocoPluginSmokeTest {
@@ -17,17 +19,14 @@ class JunitJacocoPluginSmokeTest {
         project.plugins.apply(JunitJacocoPlugin)
         //assert
         assertNotNull(project.extensions.getByName(EXTENSION_NAME), EXTENSION_NAME)
-        assertNotNull(project.extensions.getByName('junitPlatform'), 'junitPlatform')
-        def junitPlatformTestTask = project.tasks.getByName(JUNIT_TASK_NAME)
 
         assertNotNull(project.extensions.getByName('jacoco'), 'jacoco')
-        def jacocoReport = project.tasks.getByName(REPORT_TASK_NAME)
-        assertTrue(jacocoReport.reports.xml.enabled as Boolean, 'jacoco xml report is enabled by default')
-        assertFalse(jacocoReport.reports.csv.enabled as Boolean, 'jacoco csv report is disabled by default')
-        assertFalse(jacocoReport.reports.html.enabled as Boolean, 'jacoco html report is disabled by default')
+        def jacocoReport = project.tasks.getByName(JACOCO_TASK_NAME) as JacocoReport
+        assertTrue(jacocoReport.reports.xml.enabled, 'jacoco xml report is enabled by default')
+        assertFalse(jacocoReport.reports.csv.enabled, 'jacoco csv report is disabled by default')
+        assertFalse(jacocoReport.reports.html.enabled, 'jacoco html report is disabled by default')
 
         project.evaluate()
-        assertTrue(junitPlatformTestTask.args.size > 1, "$JUNIT_TASK_NAME was evaluated (has args)")
-        assertTrue(junitPlatformTestTask.args.indexOf(ARG_REPORTS_DIR) == -1, "$ARG_REPORTS_DIR is absent per default")
+        assertFalse(project.test.reports.junitXml.enabled, "junitXml report is disabled per default")
     }
 }

--- a/tutteli-gradle-junitjacoco/src/test/groovy/ch/tutteli/gradle/junitjacoco/JunitJacocoPluginTest.groovy
+++ b/tutteli-gradle-junitjacoco/src/test/groovy/ch/tutteli/gradle/junitjacoco/JunitJacocoPluginTest.groovy
@@ -4,15 +4,13 @@ import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
 
-import static ch.tutteli.gradle.junitjacoco.JunitJacocoPlugin.ARG_REPORTS_DIR
-import static ch.tutteli.gradle.junitjacoco.JunitJacocoPlugin.JUNIT_TASK_NAME
 import static ch.tutteli.gradle.junitjacoco.JunitJacocoPlugin.EXTENSION_NAME
-import static org.junit.jupiter.api.Assertions.*
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 class JunitJacocoPluginTest {
 
     @Test
-    void enableJunitReport_true_ReportsDirIsPartOfTheArguments() {
+    void enableJunitReport_true_JunitReportEnabledInGradle() {
         //arrange
         Project project = ProjectBuilder.builder().build()
         project.plugins.apply(JunitJacocoPlugin)
@@ -21,8 +19,6 @@ class JunitJacocoPluginTest {
         //act
         project.evaluate()
         //assert
-        def junitPlatformTestTask = project.tasks.getByName(JUNIT_TASK_NAME)
-        assertTrue(junitPlatformTestTask.args.size > 1, "$JUNIT_TASK_NAME was evaluated (has args)")
-        assertTrue(junitPlatformTestTask.args.indexOf(ARG_REPORTS_DIR) != -1, "$ARG_REPORTS_DIR is present")
+        assertTrue(project.test.reports.junitXml.enabled)
     }
 }

--- a/tutteli-gradle-spek/build.gradle
+++ b/tutteli-gradle-spek/build.gradle
@@ -16,5 +16,4 @@ dependencies {
      * Short for `compile project(":${rootProject.name}-junitjacoco")`
      */
     implementation prefixedProject('junitjacoco')
-    implementation "org.junit.platform:junit-platform-gradle-plugin:$junit_platform_version"
 }

--- a/tutteli-gradle-spek/src/main/groovy/ch/tutteli/gradle/spek/SpekPlugin.groovy
+++ b/tutteli-gradle-spek/src/main/groovy/ch/tutteli/gradle/spek/SpekPlugin.groovy
@@ -5,13 +5,13 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.UnknownPluginException
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
-import org.junit.platform.gradle.plugin.JUnitPlatformExtension
 
 class SpekPluginExtension {
     String version = '2.0.4'
 }
 
 class SpekPlugin implements Plugin<Project> {
+    static final String JUNIT_PLATFORM_VERSION = "5.5.1"
     static final String EXTENSION_NAME = 'spek'
     protected static
     final String ERR_KOTLIN_PLUGIN = "You need to apply a JVM compliant kotlin plugin before applying the ch.tutteli.spek plugin." +
@@ -32,12 +32,12 @@ class SpekPlugin implements Plugin<Project> {
         project.afterEvaluate {
             String spekVersion = extension.version
             boolean isVersion1 = spekVersion.startsWith("1")
-            project.extensions.getByType(JUnitPlatformExtension).filters {
-                engines {
+            project.test {
+                options {
                     if (isVersion1) {
-                        include 'spek'
+                        includeEngines 'spek'
                     } else {
-                        include 'spek2'
+                        includeEngines 'spek2'
                     }
                 }
             }
@@ -53,6 +53,7 @@ class SpekPlugin implements Plugin<Project> {
                     }
 
                     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+                    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$JUNIT_PLATFORM_VERSION"
                     testRuntimeOnly "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion" //spek requires reflect
 
                 } else {

--- a/tutteli-gradle-spek/src/test/groovy/ch/tutteli/gradle/spek/SpekPluginIntTest.groovy
+++ b/tutteli-gradle-spek/src/test/groovy/ch/tutteli/gradle/spek/SpekPluginIntTest.groovy
@@ -23,6 +23,7 @@ class SpekPluginIntTest {
         apply plugin: 'kotlin'
         apply plugin: 'ch.tutteli.spek'
         spek.version = '1.1.5'
+        ${settingsSetup.configureTestLogging()}
         """
         File kotlin = new File(settingsSetup.tmp, 'src/test/kotlin/')
         kotlin.mkdirs()
@@ -50,12 +51,12 @@ class SpekPluginIntTest {
                 ":jar",
                 ":assemble",
                 ":compileTestKotlin",
-                ":junitPlatformTest",
-                ":junitPlatformJacocoReport",
+                ":test",
+                ":jacocoTestReport",
                 ":check",
                 ":build"
             ],
-            [":test"],
+            [],
             [":classes", ":testClasses"]
         )
     }
@@ -71,6 +72,7 @@ class SpekPluginIntTest {
         apply plugin: 'kotlin'
         apply plugin: 'ch.tutteli.spek'
         spek.version = '2.0.4'
+        ${settingsSetup.configureTestLogging()}
         """
         File kotlin = new File(settingsSetup.tmp, 'src/test/kotlin/')
         kotlin.mkdirs()
@@ -100,12 +102,12 @@ class SpekPluginIntTest {
                 ":jar",
                 ":assemble",
                 ":compileTestKotlin",
-                ":junitPlatformTest",
-                ":junitPlatformJacocoReport",
+                ":test",
+                ":jacocoTestReport",
                 ":check",
                 ":build"
             ],
-            [":test"],
+            [],
             [":classes", ":testClasses"]
         )
     }


### PR DESCRIPTION
... to facilitate https://github.com/robstoll/atrium/issues/126

gives all the nice things that come with Gradle’s support for JUnit, like IDE integration.

Note:
 * This is a breaking change, because it removes `JunitJacocoPluginExtension`’s `junitPlatform`
 * I am not completely sure that this implementation maps the old behaviour 1:1, mainly because I found it difficult to understand what the intended behavior was in the first place.
 * `tutteli-gradle-junitjacoco` is now little less than a thin wrapper. It only sets some defaults. I would recommend to remove it altogether and set the defaults explicitly in projects. I do not think that the plugin is worth its effort anymore.