### PR TITLE
Allow to publish with module info & compat to Java 8

### DIFF
--- a/tutteli-gradle-kotlin-module-info/build.gradle
+++ b/tutteli-gradle-kotlin-module-info/build.gradle
@@ -7,3 +7,7 @@ buildscript {
         plugin_tags = ['kotlin', 'module-info', 'jigsaw']
     }
 }
+
+dependencies {
+    testImplementation "com.jayway.jsonpath:json-path-assert:2.2.0"
+}

--- a/tutteli-gradle-kotlin-module-info/src/main/groovy/ch/tutteli/gradle/kotlin/module/info/ModuleInfoPlugin.groovy
+++ b/tutteli-gradle-kotlin-module-info/src/main/groovy/ch/tutteli/gradle/kotlin/module/info/ModuleInfoPlugin.groovy
@@ -37,6 +37,8 @@ class ModuleInfoPlugin implements Plugin<Project> {
             project.compileModuleJava.configure {
                 dependsOn project.compileKotlin
                 destinationDir = project.compileKotlin.destinationDir
+                sourceCompatibility = 9
+                targetCompatibility = 9
                 doFirst {
                     options.compilerArgs = ['--module-path', classpath.asPath]
                     classpath = project.files()


### PR DESCRIPTION
The changes allow us to declare

```groovy
sourceCompatibility = 8
targetCompatibility = 8
```

in `build.gradle`. This will yield an artefact that can be used on JVM 8 but still has a `module-info.class`.

Note that I have not actually tested to consume the resulting JAR. But this thread claims that it will work: https://stackoverflow.com/questions/48928723/gradle-building-a-modularized-library-that-is-compatible-with-java-8