### PR TITLE
create proper task class for manifest augmentation, check GPG on publish

### DIFF
--- a/test-utils/src/main/groovy/ch/tutteli/gradle/plugins/test/Asserts.groovy
+++ b/test-utils/src/main/groovy/ch/tutteli/gradle/plugins/test/Asserts.groovy
@@ -1,10 +1,11 @@
 package ch.tutteli.gradle.plugins.test
 
+
+import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.function.Executable
-
 
 import static org.junit.jupiter.api.Assertions.*
 
@@ -78,5 +79,15 @@ class Asserts {
         //assert
         assertEquals(cause, exception.cause.class)
         assertEquals(message, exception.cause.message)
+    }
+
+    static void assertTaskExists(Project project, String taskName) {
+        def task = project.tasks.findByName(taskName)
+        if (task == null) {
+            fail("could not find task $taskName")
+            //TODO 5.0.0 check if we can use the following with gradle 8.1.x, instead of the above,
+            // currently we cannot due to the following bug https://github.com/gradle/gradle/issues/20301
+//            fail("could not find task $taskName, there were ${project.tasks.collect { it.name }.join(",")}")
+        }
     }
 }

--- a/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/AugmentManifestInJarTask.kt
+++ b/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/AugmentManifestInJarTask.kt
@@ -1,0 +1,82 @@
+package ch.tutteli.gradle.plugins.publish
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.PluginContainer
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.reflect.full.memberProperties
+
+abstract class AugmentManifestInJarTask : DefaultTask() {
+
+    @get:Input
+    abstract val jarTask: Property<Jar>
+
+    @TaskAction
+    fun configure() {
+        val extension = project.extensions.getByType<PublishPluginExtension>()
+        augmentManifest(extension)
+    }
+
+    private fun augmentManifest(extension: PublishPluginExtension) {
+        val repoUrl = extension.determineRepoDomainAndPath()
+        jarTask.get().apply {
+            manifest {
+                attributes(
+                    mapOf(
+                        "Implementation-Title" to project.name,
+
+                        "Implementation-Version" to project.version,
+                        "Implementation-URL" to "https://$repoUrl",
+                        "Build-Time" to ZonedDateTime.now().format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
+                    ) + getVendorIfAvailable(extension) + getImplementationKotlinVersionIfAvailable(project)
+                )
+                listOf("LICENSE.txt", "LICENSE", "LICENSE.md", "LICENSE.rst").forEach { fileName ->
+                    val licenseFile = project.file("${project.rootProject.projectDir}/$fileName")
+                    if (licenseFile.exists()) this@apply.from(licenseFile)
+                }
+            }
+        }
+    }
+
+
+    private fun getVendorIfAvailable(extension: PublishPluginExtension): Map<String, String> =
+        if (extension.manifestVendor.isPresent) mapOf("Implementation-Vendor" to extension.manifestVendor.get())
+        else emptyMap()
+
+    private fun getImplementationKotlinVersionIfAvailable(project: Project): Map<String, String> {
+        val kotlinVersion = getKotlinVersion(project)
+        return if (kotlinVersion != null) mapOf("Implementation-Kotlin-Version" to kotlinVersion)
+        else emptyMap()
+    }
+
+    private fun getKotlinVersion(project: Project): String? {
+        val version = try {
+            project.getKotlinPluginVersion()
+        } catch (e: NoClassDefFoundError) {
+            // KotlinPluginWrapperKt (source where extension method getKotlinPluginVersion is defined) might not exist
+            // if no kotlin plugin was applied or an old one or an old gradle version is used where the extension
+            // method on Project does not exist yet
+            null
+        }
+        return version ?: (project.plugins.let<PluginContainer, Plugin<*>?> {
+            // TODO 5.0.0 drop once we no longer support the old kotlin plugins and old gradle version
+            it.findPlugin("kotlin") ?: it.findPlugin("kotlin2js") ?: it.findPlugin("kotlin-platform-jvm")
+            ?: it.findPlugin("kotlin-platform-js") ?: it.findPlugin("kotlin-common")
+            ?: it.findPlugin("org.jetbrains.kotlin.multiplatform") ?: it.findPlugin("org.jetbrains.kotlin.jvm")
+            ?: it.findPlugin("org.jetbrains.kotlin.js")
+        }?.let {
+            val value = it::class.memberProperties.find { property ->
+                property.name == "kotlinPluginVersion"
+            }?.call(it)
+            (value as? CharSequence)?.toString()
+        })
+    }
+}

--- a/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/PomAugmenter.kt
+++ b/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/PomAugmenter.kt
@@ -1,0 +1,54 @@
+package ch.tutteli.gradle.plugins.publish
+
+import org.gradle.api.Project
+import org.gradle.api.publish.maven.MavenPublication
+
+
+class PomAugmenter(
+    private val project: Project,
+    private val extension: PublishPluginExtension
+) {
+
+    fun augment(publication: MavenPublication) {
+        val domainAndPath = extension.determineRepoDomainAndPath()
+        val extensionLicenses = extension.licenses.getOrElse(emptyList())
+        val uniqueLicenses = extensionLicenses.toSortedSet()
+        if (extensionLicenses.size != uniqueLicenses.size) {
+            PublishPlugin.LOGGER.warn("Some licenses were duplicated. Please check if you made a mistake.")
+        }
+
+        publication.pom {
+            name.set(project.name)
+            description.set(project.description)
+            url.set("https://$domainAndPath")
+
+            licenses {
+                uniqueLicenses.forEach { chosenLicense ->
+                    license {
+                        name.set(chosenLicense.longName)
+                        url.set(chosenLicense.url)
+                        distribution.set(chosenLicense.distribution)
+                    }
+                }
+            }
+            developers {
+                extension.developers.getOrElse(emptyList()).forEach { dev ->
+                    developer {
+                        id.set(dev.id)
+                        if (dev.name.isNullOrBlank().not()) name.set(dev.name)
+                        if (dev.email.isNullOrBlank().not()) email.set(dev.email)
+                        if (dev.url.isNullOrBlank().not()) url.set(dev.url)
+                        if (dev.organization.isNullOrBlank().not()) organization.set(dev.organization)
+                        if (dev.organizationUrl.isNullOrBlank().not()) organizationUrl.set(dev.organizationUrl)
+                        //never used roles, timezone so far, skip it for now
+                    }
+                }
+            }
+            scm {
+                connection.set("scm:git:git://${domainAndPath}.git")
+                developerConnection.set("scm:git:ssh://${domainAndPath}.git")
+                url.set("https://$domainAndPath")
+            }
+        }
+    }
+}

--- a/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/PublishPlugin.kt
+++ b/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/PublishPlugin.kt
@@ -3,7 +3,6 @@ package ch.tutteli.gradle.plugins.publish
 import org.gradle.api.*
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
@@ -11,14 +10,6 @@ import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.signing.SigningExtension
 import org.gradle.plugins.signing.SigningPlugin
-import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
-import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
-import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
-import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
-import kotlin.reflect.full.functions
-import kotlin.reflect.full.memberProperties
 
 class PublishPlugin : Plugin<Project> {
 
@@ -26,7 +17,7 @@ class PublishPlugin : Plugin<Project> {
         val LOGGER: Logger = Logging.getLogger(PublishPlugin::class.java)
         const val EXTENSION_NAME = "tutteliPublish"
         private const val PUBLICATION_NAME = "tutteli"
-        const val TASK_NAME_INCLUDE_TIME = "includeBuildTimeInManifest"
+        const val TASK_NAME_PREFIX_AUGMENT_MANIFEST_IN_JAR = "augmentManifestIn-"
         const val TASK_NAME_VALIDATE_PUBLISH = "validateBeforePublish"
         val TASK_GENERATE_POM = "generatePomFileFor${PUBLICATION_NAME.capitalize()}Publication"
         val TASK_GENERATE_GRADLE_METADATA = "generateMetadataFileFor${PUBLICATION_NAME.capitalize()}Publication"
@@ -39,24 +30,7 @@ class PublishPlugin : Plugin<Project> {
 
         val extension = project.extensions.create<PublishPluginExtension>(EXTENSION_NAME, project)
 
-        val validateBeforePublish = project.tasks.register<ValidateBeforePublishTask>(TASK_NAME_VALIDATE_PUBLISH)
-
-        val includeBuildTime = project.tasks.register(TASK_NAME_INCLUDE_TIME) {
-            doLast {
-                jarTasks(project, extension).forEach {
-                    augmentManifest(it, project, extension)
-                }
-            }
-        }
-
-        includeBuildTime.configure {
-            dependsOn(validateBeforePublish)
-        }
-
         project.afterEvaluate {
-            jarTasks(project, extension).forEach {
-                it.mustRunAfter(includeBuildTime)
-            }
             project.version = determineVersion(project) ?: determineVersion(project.rootProject) ?: ""
             project.group = determineGroup(project) ?: determineGroup(project.rootProject) ?: ""
             checkNotNullNorBlank(project.name, "project.name")
@@ -65,69 +39,69 @@ class PublishPlugin : Plugin<Project> {
             checkNotNullNorBlank(project.description, "project.description")
             checkExtensionPropertyPresentAndNotBlank(extension.githubUser, "githubUser")
             checkExtensionPropertyPresentNotEmpty(extension.licenses, "licenses")
-            checkExtensionPropertyPresentAndNotBlank(extension.envNameGpgPassphrase, "envNameGpgPassphrase")
-            checkExtensionPropertyPresentAndNotBlank(extension.envNameGpgKeyId, "envNameGpgKeyId")
-            checkExtensionPropertyPresentAndNotBlank(extension.envNameGpgKeyRing, "envNameGpgKeyRing")
-            checkExtensionPropertyPresentAndNotBlank(extension.envNameGpgSigningKey, "envNameGpgSigningKey")
 
-            val signingExtension = project.extensions.getByType<SigningExtension>()
+            jarTasks(project, extension) {
+                val jarTask = this
+                val augmentTaskName = TASK_NAME_PREFIX_AUGMENT_MANIFEST_IN_JAR + jarTask.name
+                val augmentTask = project.tasks.register<AugmentManifestInJarTask>(augmentTaskName) {
+                    this.jarTask.set(jarTask)
+                }
+                jarTask.dependsOn(augmentTask)
+            }
+
             var publications = getMavenPublications(project)
             val usesOwnPublications = publications.isNotEmpty()
             if (!usesOwnPublications) {
-                // we only create the tutteli publication in case there is not already one (e.g. MPP creates own publications)
-                configurePublishing(project, extension)
+                // we only create the tutteli publication in case there is not already one
+                // (e.g. MPP creates own publications)
+                registerTutteliPublication(project, extension)
                 publications = getMavenPublications(project)
             }
-            publications.forEach { publication ->
-                configurePom(publication, project, extension)
 
+            val signingExtension = project.the<SigningExtension>()
+            val validateBeforePublish = project.tasks.register<ValidateBeforePublishTask>(TASK_NAME_VALIDATE_PUBLISH)
 
-                // was a workaround for signing SNAPSHOTs, looks like this is no longer a problem,
-                // I keep it here in case it re-appears. Can be removed after some time I guess
-//                    def version = String.valueOf(project.version)
-//                    // change version for signing only, we change it back afterwards
-//                    if (version.endsWith("-SNAPSHOT")) {
-//                        project.version = version.substring(0, version.lastIndexOf("-SNAPSHOT"))
-//                    }
-                signingExtension.sign(publication)
-//                    project.version = version
+            val pomAugmenter = PomAugmenter(project, extension)
+            publications.configureEach {
+                val publication = this
+                pomAugmenter.augment(this)
 
                 val taskSuffix = "${publication.name.capitalize()}Publication"
-                project.tasks.named("generatePomFileFor$taskSuffix").configure {
-                    dependsOn(includeBuildTime)
+
+                // creates the sign task -- tasks if we would pass more than one publication
+                signingExtension.sign(publication).forEach { signTask ->
+                    signTask.dependsOn(validateBeforePublish)
+
+                    project.tasks.named("publish${taskSuffix}ToMavenLocal").configure {
+                        dependsOn(signTask)
+                    }
                 }
-                val signTask = project.tasks.named("sign$taskSuffix")
-                project.tasks.named("publish${taskSuffix}ToMavenLocal").configure {
-                    dependsOn(signTask)
-                }
-            }
-            if (usesOwnPublications && project.plugins.findPlugin("org.jetbrains.kotlin.multiplatform") != null) {
+
                 // in case we generate a javadocJar (e.g. via tutteli's dokka plugin) then we add it to each publication
-                val javadocJar = project.tasks.findByName("javadocJar")
-                if (javadocJar != null) {
-                    publications
-                        // don't add javadocJar to a "relocation" publication
-                        .filterNot { it.name.endsWith("-relocation") }
-                        .forEach { publication ->
-                            publication.artifact(javadocJar)
-                        }
+                // but only if it is not a ...-relocation publication
+                // and only if the project has defined own publications and the new MPP plugin is available. Because
+                // we fear that other plugins might add javadoc as magically as we do it here and we only want to
+                // do it if MPP is available (doesn't mean there could not be another plugin which still does magic stuff)
+                if (!publication.name.endsWith("-relocation") &&
+                    usesOwnPublications &&
+                    project.plugins.findPlugin("org.jetbrains.kotlin.multiplatform") != null
+                ) {
+                    project.tasks.findByName("javadocJar")?.let { javadocJar ->
+                        publication.artifact(javadocJar)
+                    }
                 }
             }
         }
     }
 
-
-    private fun jarTasks(project: Project, extension: PublishPluginExtension): Set<Jar> =
-        project.tasks.withType<Jar>().filter {
-            !extension.artifactFilter.isPresent || extension.artifactFilter.get().invoke(it)
-        }.toSet()
-
+    private fun jarTasks(project: Project, extension: PublishPluginExtension, action: Action<Jar>): Unit =
+        project.tasks.withType<Jar>()
+            .matching { !extension.artifactFilter.isPresent || extension.artifactFilter.get().invoke(it) }
+            //TODO 5.0.0 check if we can use configureEach with gradle 8.x
+            .all(action)
 
     private fun getMavenPublications(project: Project): NamedDomainObjectCollection<MavenPublication> =
-        project.extensions.getByType<PublishingExtension>().publications.withType<MavenPublication>()
-
-    private fun determineRepoDomainAndPath(project: Project, extension: PublishPluginExtension): String =
-        "github.com/${extension.githubUser.get()}/${project.rootProject.name}"
+        project.the<PublishingExtension>().publications.withType<MavenPublication>()
 
     private fun determineVersion(project: Project): String? =
         if (project.version == "unspecified") null else project.versionAsString
@@ -140,8 +114,8 @@ class PublishPlugin : Plugin<Project> {
         return if (group.isNullOrBlank()) null else group
     }
 
-    private fun configurePublishing(project: Project, extension: PublishPluginExtension) {
-        project.extensions.getByType<PublishingExtension>().publications {
+    private fun registerTutteliPublication(project: Project, extension: PublishPluginExtension) {
+        project.the<PublishingExtension>().publications {
             register<MavenPublication>(PUBLICATION_NAME) {
                 groupId = (project.group as? CharSequence)?.toString()
                     ?: throw IllegalStateException("project.group needs to be a string as it is used as groupId for the maven publication coordinates")
@@ -159,113 +133,10 @@ class PublishPlugin : Plugin<Project> {
                         }
                     }
                 }
-                jarTasks(project, extension).forEach {
-                    artifact(it)
+                jarTasks(project, extension) {
+                    artifact(this)
                 }
             }
         }
-    }
-
-    private fun configurePom(publication: MavenPublication, project: Project, extension: PublishPluginExtension) {
-        val domainAndPath = determineRepoDomainAndPath(project, extension)
-        val extensionLicenses = extension.licenses.getOrElse(emptyList())
-        val uniqueLicenses = extensionLicenses.toSortedSet()
-        if (extensionLicenses.size != uniqueLicenses.size) {
-            LOGGER.warn("Some licenses were duplicated. Please check if you made a mistake.")
-        }
-
-        publication.pom {
-            name.set(project.name)
-            description.set(project.description)
-            url.set("https://$domainAndPath")
-
-            licenses {
-                uniqueLicenses.forEach { chosenLicense ->
-                    license {
-                        name.set(chosenLicense.longName)
-                        url.set(chosenLicense.url)
-                        distribution.set(chosenLicense.distribution)
-                    }
-                }
-            }
-            developers {
-                extension.developers.getOrElse(emptyList()).forEach { dev ->
-                    developer {
-                        id.set(dev.id)
-                        if (dev.name.isNullOrBlank().not()) name.set(dev.name)
-                        if (dev.email.isNullOrBlank().not()) email.set(dev.email)
-                        if (dev.url.isNullOrBlank().not()) url.set(dev.url)
-                        if (dev.organization.isNullOrBlank().not()) organization.set(dev.organization)
-                        if (dev.organizationUrl.isNullOrBlank().not()) organizationUrl.set(dev.organizationUrl)
-                        //never used roles, timezone so far, skip it for now
-                    }
-                }
-            }
-            scm {
-                connection.set("scm:git:git://${domainAndPath}.git")
-                developerConnection.set("scm:git:ssh://${domainAndPath}.git")
-                url.set("https://$domainAndPath")
-            }
-        }
-    }
-
-
-    private fun augmentManifest(task: Jar, project: Project, extension: PublishPluginExtension) {
-        val repoUrl = determineRepoDomainAndPath(project, extension)
-        task.manifest {
-            attributes(
-                mapOf(
-                    "Implementation-Title" to project.name,
-
-                    "Implementation-Version" to project.version,
-                    "Implementation-URL" to "https://$repoUrl",
-                    "Build-Time" to ZonedDateTime.now().format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
-                )
-                    + getVendorIfAvailable(extension) + getImplementationKotlinVersionIfAvailable(project)
-            )
-            listOf("LICENSE.txt", "LICENSE", "LICENSE.md", "LICENSE.rst").forEach { fileName ->
-                val licenseFile = project.file("${project.rootProject.projectDir}/$fileName")
-                if (licenseFile.exists()) task.from(licenseFile)
-            }
-        }
-    }
-
-    private fun getVendorIfAvailable(extension: PublishPluginExtension): Map<String, String> =
-        if (extension.manifestVendor.isPresent) mapOf("Implementation-Vendor" to extension.manifestVendor.get())
-        else emptyMap()
-
-    private fun getImplementationKotlinVersionIfAvailable(project: Project): Map<String, String> {
-        val kotlinVersion = getKotlinVersion(project)
-        // we use if instead of ternary operator because type inference fails otherwise
-        return if (kotlinVersion != null) mapOf("Implementation-Kotlin-Version" to kotlinVersion)
-        else emptyMap()
-    }
-
-    private fun getKotlinVersion(project: Project): String? {
-        val version = try {
-            project.getKotlinPluginVersion()
-        } catch (e: NoClassDefFoundError) {
-            // KotlinPluginWrapperKt (source where extension method getKotlinPluginVersion is defined) might not exist
-            // if no kotlin plugin was applied or an old one or an old gradle version is used where the extension
-            // method on Project does not exist yet
-            null
-        }
-        return version
-            ?: (project.plugins.let<PluginContainer, Plugin<*>?> {
-                // TODO drop once we no longer support the old kotlin plugins and old gradle version
-                it.findPlugin("kotlin")
-                    ?: it.findPlugin("kotlin2js")
-                    ?: it.findPlugin("kotlin-platform-jvm")
-                    ?: it.findPlugin("kotlin-platform-js")
-                    ?: it.findPlugin("kotlin-common")
-                    ?: it.findPlugin("org.jetbrains.kotlin.multiplatform")
-                    ?: it.findPlugin("org.jetbrains.kotlin.jvm")
-                    ?: it.findPlugin("org.jetbrains.kotlin.js")
-            }?.let {
-                val value = it::class.memberProperties.find { property ->
-                    property.name == "kotlinPluginVersion"
-                }?.call(it)
-                (value as? CharSequence)?.toString()
-            })
     }
 }

--- a/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/PublishPluginExtension.kt
+++ b/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/PublishPluginExtension.kt
@@ -135,10 +135,13 @@ open class PublishPluginExtension(private val project: Project) {
         licenses.add(license)
     }
 
-
     fun developer(developer: Action<Developer>) {
         val newDeveloper = project.objects.newInstance(Developer::class.java)
         developer.execute(newDeveloper)
         developers.add(newDeveloper)
     }
+
+    fun determineRepoDomainAndPath(): String =
+        "github.com/${githubUser.get()}/${project.rootProject.name}"
+
 }

--- a/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/Validation.kt
+++ b/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/Validation.kt
@@ -5,19 +5,19 @@ import org.gradle.api.provider.Property
 
 
 fun checkNotNullNorBlank(value: Any?, valueDescription: String) {
-    if ((value as? CharSequence).isNullOrBlank()) throwIllegalState(valueDescription)
+    if ((value as? CharSequence).isNullOrBlank()) throwIllegalStateException(valueDescription)
 }
 
 fun checkExtensionPropertyPresentAndNotBlank(property: Property<String>, propertyName: String) {
-    if (property.orNull.isNullOrBlank()) newIllegalStateForProperty(propertyName)
+    if (property.orNull.isNullOrBlank()) throwIllegalStateExceptionForProperty(propertyName)
 }
 
 fun checkExtensionPropertyPresentNotEmpty(property: ListProperty<*>, propertyName: String) {
-    if ((property.isPresent && property.get().isNotEmpty()).not()) newIllegalStateForProperty(propertyName)
+    if ((property.isPresent && property.get().isNotEmpty()).not()) throwIllegalStateExceptionForProperty(propertyName)
 }
 
-fun newIllegalStateForProperty(propertyName: String): Nothing =
-    throwIllegalState("${PublishPlugin.EXTENSION_NAME}.$propertyName")
+fun throwIllegalStateExceptionForProperty(propertyName: String): Nothing =
+    throwIllegalStateException("${PublishPlugin.EXTENSION_NAME}.$propertyName")
 
-fun throwIllegalState(description: String): Nothing =
+fun throwIllegalStateException(description: String): Nothing =
     throw IllegalStateException("You need to define $description for publishing (empty or blank is considered to be undefined)")

--- a/tutteli-gradle-publish/src/test/groovy/ch/tutteli/gradle/plugins/publish/PublishPluginIntTest.groovy
+++ b/tutteli-gradle-publish/src/test/groovy/ch/tutteli/gradle/plugins/publish/PublishPluginIntTest.groovy
@@ -35,7 +35,7 @@ class PublishPluginIntTest {
     }
 
     @Test
-    void smokeTestJava_6x(SettingsExtensionObject settingsSetup) throws IOException {
+    void smokeTestJava_gradle6x(SettingsExtensionObject settingsSetup) throws IOException {
         //arrange
         def version = '1.0.0'
         checkSmokeTestJava("smoke1", settingsSetup, version, "6.9.4")
@@ -74,7 +74,6 @@ class PublishPluginIntTest {
             }
         }
 
-        // has to be before ch.tutteli.publish
         apply plugin: 'java'
         apply plugin: 'ch.tutteli.gradle.plugins.publish'
 
@@ -163,6 +162,7 @@ class PublishPluginIntTest {
             .withProjectDir(settingsSetup.tmp)
             .withArguments("publishAllPublicationsToMavenRepository", "printSigning", "--stacktrace")
             .build()
+
         //assert
         assertTrue(result.output.contains("Some licenses were duplicated. Please check if you made a mistake."), "should contain warning about duplicated licenses:\n$result.output")
 
@@ -227,7 +227,7 @@ class PublishPluginIntTest {
                 classpath files($settingsSetup.pluginClasspath)
             }
         }
-        // has to be before ch.tutteli.publish
+
         apply plugin: 'java'
         apply plugin: 'ch.tutteli.gradle.plugins.publish'
 
@@ -243,10 +243,10 @@ class PublishPluginIntTest {
             // gpg passphrase not defined via property or something
         }
         """
-        //act
+        // still able to generate a pom, the GPG-key is only used for publishing
         GradleRunner.create()
             .withProjectDir(settingsSetup.tmp)
-            .withArguments("tasks", "--stacktrace")
+            .withArguments("tasks", "generatePom", "--stacktrace")
             .build()
         //assert
         def exception = assertThrows(UnexpectedBuildFailure) {
@@ -265,12 +265,12 @@ class PublishPluginIntTest {
     }
 
     @Test
-    void subproject_6_x(SettingsExtensionObject settingsSetup) throws IOException {
+    void subproject_gradle6x(SettingsExtensionObject settingsSetup) throws IOException {
         checkSubproject(settingsSetup, "6.9.4")
     }
 
     private void checkSubproject(SettingsExtensionObject settingsSetup, String gradleVersion = null) {
-//arrange
+        //arrange
         def rootProjectName = 'rootProject'
         def subprojectName = "test-sub-jvm"
         def dependentName = 'dependent'
@@ -362,7 +362,6 @@ class PublishPluginIntTest {
             .withProjectDir(settingsSetup.tmp)
             .withArguments("publishAllPublicationsToMavenRepository", "printSigning", "--stacktrace")
             .build()
-
 
         //assert
         assertSigning(result, gpgPassphrase, gpgKeyId, "${settingsSetup.tmpPath.toRealPath()}/$gpgKeyRing")
@@ -624,7 +623,7 @@ class PublishPluginIntTest {
     }
 
     @Test
-    void withKotlinMultiplatformApplied_Kotlin1_8(SettingsExtensionObject settingsSetup) throws IOException {
+    void withKotlinMultiplatformApplied_Kotlin1_7(SettingsExtensionObject settingsSetup) throws IOException {
         checkKotlinMultiplatform('mpp-kotlin-1.7.0', settingsSetup, false, "1.7.0")
     }
 
@@ -737,7 +736,7 @@ class PublishPluginIntTest {
         }
         def result = builder
             .withProjectDir(settingsSetup.tmp)
-            .withArguments("publishAllPublicationsToMavenRepository", "printSigning")
+            .withArguments("publishAllPublicationsToMavenRepository", "printSigning", "--stacktrace")
             .build()
 
         Asserts.assertTaskNotInvolved(result, ":$PublishPlugin.TASK_GENERATE_GRADLE_METADATA")

--- a/tutteli-gradle-publish/src/test/groovy/ch/tutteli/gradle/plugins/publish/PublishPluginValidationTest.groovy
+++ b/tutteli-gradle-publish/src/test/groovy/ch/tutteli/gradle/plugins/publish/PublishPluginValidationTest.groovy
@@ -2,7 +2,6 @@ package ch.tutteli.gradle.plugins.publish
 
 import org.gradle.api.Project
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.function.Executable
 
 import static ch.tutteli.gradle.plugins.publish.SetUp.*
 import static ch.tutteli.gradle.plugins.test.Asserts.assertThrowsProjectConfigExceptionWithCause
@@ -108,13 +107,6 @@ class PublishPluginValidationTest {
         project.evaluate()
 
         assertTrue(getPluginExtension(project).signWithGpg.get())
-    }
-
-    private static void assertThrowsIllegalState(String what, Executable executable) {
-        def exception = assertThrows(IllegalStateException) {
-            executable.execute()
-        }
-        assertEquals(getExceptionMessage(what), exception.message)
     }
 
     private static void assertThrowsProjectConfigWithCauseIllegalStateNotDefined(String what, Project project) {

--- a/tutteli-gradle-publish/src/test/groovy/ch/tutteli/gradle/plugins/publish/ValidateBeforePublishTaskTest.groovy
+++ b/tutteli-gradle-publish/src/test/groovy/ch/tutteli/gradle/plugins/publish/ValidateBeforePublishTaskTest.groovy
@@ -4,8 +4,10 @@ import org.gradle.api.Project
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.function.Executable
 
-import static ch.tutteli.gradle.plugins.publish.SetUp.*
-import static org.junit.jupiter.api.Assertions.*
+import static ch.tutteli.gradle.plugins.publish.SetUp.getPluginExtension
+import static ch.tutteli.gradle.plugins.publish.SetUp.setUp
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
 
 class ValidateBeforePublishTaskTest {
 


### PR DESCRIPTION
regarding GPG, check for GPG key only if we publish and not already when we generate a pom.

moreover:
- also move logic to augment pom into own class

fixes #215