### PR TITLE
support java toolchain

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        java_version: [ 11, 14 ]
+        java_version: [ 11, 17 ]
 
     steps:
       - uses: actions/checkout@v3
@@ -18,6 +18,8 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.java_version }}
       - name: build
+        env:
+          JAVA_VERSION: ${{ matrix.java_version }}
         run: ./gradlew build
       - name: Upload build code coverage
         uses: codecov/codecov-action@v3.1.3

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -8,8 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # re-add 17 once we update gradle, yet windows had problems with module-info tests when two jobs run at the same time
-        java_version: [ 11, 14 ]
+        java_version: [ 11, 17 ]
 
     steps:
       - uses: actions/checkout@v3
@@ -19,6 +18,8 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.java_version }}
       - name: build
+        env:
+          JAVA_VERSION: ${{ matrix.java_version }}
         run: ./gradlew build
       - name: Upload build code coverage
         uses: codecov/codecov-action@v3.1.3

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In case you should use Spek as your engine, then you might want to have a look a
 # ch.tutteli.gradle.plugins.kotlin.module.info [🔗](https://plugins.gradle.org/plugin/ch.tutteli.gradle.plugins.kotlin.module.info/4.8.0)
 
 Intended to be used in a kotlin project where either module-info.java is the single java source file or where >= jdk 11 is used.
-It sets up compileJava accordingly and configures the java extension to use jdk 11 for `sourceCompatibility`/`targetCompatibility` if not already set or higher. 
+It sets up compileJava accordingly and configures JavaCompile tasks to use jdk 11 for `sourceCompatibility`/`targetCompatibility` if not already set or higher. 
 
 Per default, it reads the module name (which is used for `--patch-module`) from the defined module-info.java. 
 You can speed up this process (in case you have many java files) by defining `moduleName` on `project.extra`.
@@ -81,7 +81,7 @@ If not set, it automatically propagates `version` and `group` from `rootProject`
 (`group` of subprojects are set to "" when plugin is applied, would default to `rootProject.name`).
 
 If no MavenPublication is defined, then it creates one which:
-- automatically uses `project.components.java` if available -- apply the `java` or `kotlin` plugin (or similar) first.
+- automatically uses `project.components.java` if available.
 - includes all Jar Tasks into the publication
 
 Regardless if there was one or several existing MavenPublications or one was created by the plugin.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,16 +99,25 @@ subprojects {
     version = rootProject.version
     group = rootProject.group
 
-    java {
-        toolchain {
-            languageVersion.set(JavaLanguageVersion.of(8))
-        }
-    }
-
     repositories {
         mavenCentral()
     }
+
+    java {
+        toolchain {
+            // reading JAVA_VERSION from env to enable jdk17 build in CI
+            val jdkVersion = System.getenv("JAVA_VERSION")?.toIntOrNull() ?: 11
+            languageVersion.set(JavaLanguageVersion.of(jdkVersion))
+        }
+    }
+
+    tasks.withType<JavaCompile> {
+        sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+        targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    }
 }
+
+
 
 val pluginProjects = subprojects - project(":test-utils")
 configure(pluginProjects) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,10 +99,10 @@ subprojects {
     version = rootProject.version
     group = rootProject.group
 
-    with(the<JavaPluginExtension>()) {
-        // TODO change to JDK11 with 5.0.0
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(8))
+        }
     }
 
     repositories {

--- a/tutteli-gradle-kotlin-module-info/src/test/groovy/ch/tutteli/gradle/plugins/kotlin/module/info/ModuleInfoPluginIntTest.groovy
+++ b/tutteli-gradle-kotlin-module-info/src/test/groovy/ch/tutteli/gradle/plugins/kotlin/module/info/ModuleInfoPluginIntTest.groovy
@@ -304,7 +304,7 @@ class ModuleInfoPluginIntTest {
         module.mkdirs()
         def moduleInfo = new File(module, 'module-info.java')
         def moduleInfoId = (projectName.replace(".", "_") + "_" + UUID.randomUUID().toString()).replace('-', '_')
-        moduleInfo << "module ch.tutteli.${ moduleInfoId} { $moduleInfoContent }"
+        moduleInfo << "module ch.tutteli.${moduleInfoId} { $moduleInfoContent }"
         def kotlin = new File(settingsSetup.tmp, 'sub1/src/main/kotlin')
         kotlin.mkdirs()
         def test = new File(kotlin, 'test.kt')
@@ -332,5 +332,36 @@ class ModuleInfoPluginIntTest {
             }
             """
     }
+
+    @Test
+    void worksIfOneHasAppliedJavaToolchain(SettingsExtensionObject settingsSetup) {
+        def projectName="java-toolchain"
+        settingsSetup.settings << "rootProject.name='$projectName'"
+        settingsSetup.buildGradle << """
+            ${settingsSetup.buildscriptWithKotlin(KOTLIN_VERSION)}
+
+            apply plugin: 'org.jetbrains.kotlin.jvm'
+            apply plugin: 'ch.tutteli.gradle.plugins.kotlin.module.info'
+
+            repositories {
+                mavenCentral()
+            }
+
+            project.version = '1.2.3'
+
+            java {
+                toolchain {
+                     languageVersion.set(JavaLanguageVersion.of(11))
+                }
+            }
+            """
+        def module = new File(settingsSetup.tmp, 'src/main/java/')
+        module.mkdirs()
+        def moduleInfo = new File(module, 'module-info.java')
+        def moduleInfoId = (projectName.replace(".", "_") + "_" + UUID.randomUUID().toString()).replace('-', '_')
+        moduleInfo << "module ch.tutteli.$moduleInfoId { requires java.base; }"
+        def result = runGradleModuleBuild(settingsSetup, null, "build")
+    }
+
 
 }

--- a/tutteli-gradle-kotlin-module-info/src/test/groovy/ch/tutteli/gradle/plugins/kotlin/module/info/ModuleInfoPluginIntTest.groovy
+++ b/tutteli-gradle-kotlin-module-info/src/test/groovy/ch/tutteli/gradle/plugins/kotlin/module/info/ModuleInfoPluginIntTest.groovy
@@ -3,6 +3,8 @@ package ch.tutteli.gradle.plugins.kotlin.module.info
 import ch.tutteli.gradle.plugins.test.Asserts
 import ch.tutteli.gradle.plugins.test.SettingsExtension
 import ch.tutteli.gradle.plugins.test.SettingsExtensionObject
+import org.gradle.api.JavaVersion
+import org.gradle.internal.impldep.com.google.common.reflect.Types
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
@@ -155,6 +157,8 @@ class ModuleInfoPluginIntTest {
 
     @Test
     void moduleInfoSucceeds_MultiplatformPlugin_Gradle6_9_3(SettingsExtensionObject settingsSetup) {
+        def javaVersion = JavaVersion.toVersion(System.getProperty("java.version"))
+        assumeFalse(javaVersion >= JavaVersion.VERSION_15)
         checkSucceeds("mpp-6.9.3-success", settingsSetup, "6.9.3", MULTIPLATFORM_PLUGIN,
             """
             kotlin {
@@ -213,8 +217,10 @@ class ModuleInfoPluginIntTest {
 
     @Test
     void moduleInfoInSubproject_gradle6x_Succeeds(SettingsExtensionObject settingsSetup) {
-        //not for jdk8
-        assumeFalse(System.getProperty("java.version").startsWith("1.8"))
+        //not for jdk8, and gradle 6.9.3 is not compatible with
+        def javaVersion = JavaVersion.toVersion(System.getProperty("java.version"))
+        assumeFalse(javaVersion <= JavaVersion.VERSION_1_8)
+        assumeFalse(javaVersion >= JavaVersion.VERSION_15)
         //arrange
         setupModuleInfoInSubproject("sub-jvm-6.9.3-success", settingsSetup, "requires kotlin.stdlib; requires ch.tutteli.atrium.fluent.en_GB;")
         try {
@@ -335,7 +341,7 @@ class ModuleInfoPluginIntTest {
 
     @Test
     void worksIfOneHasAppliedJavaToolchain(SettingsExtensionObject settingsSetup) {
-        def projectName="java-toolchain"
+        def projectName = "java-toolchain"
         settingsSetup.settings << "rootProject.name='$projectName'"
         settingsSetup.buildGradle << """
             ${settingsSetup.buildscriptWithKotlin(KOTLIN_VERSION)}

--- a/tutteli-gradle-publish/src/test/groovy/ch/tutteli/gradle/plugins/publish/PublishPluginIntTest.groovy
+++ b/tutteli-gradle-publish/src/test/groovy/ch/tutteli/gradle/plugins/publish/PublishPluginIntTest.groovy
@@ -3,6 +3,7 @@ package ch.tutteli.gradle.plugins.publish
 import ch.tutteli.gradle.plugins.test.Asserts
 import ch.tutteli.gradle.plugins.test.SettingsExtension
 import ch.tutteli.gradle.plugins.test.SettingsExtensionObject
+import org.gradle.api.JavaVersion
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
@@ -19,6 +20,8 @@ import static ch.tutteli.gradle.plugins.test.Asserts.NL_INDENT
 import static ch.tutteli.gradle.plugins.test.Asserts.assertContainsNotRegex
 import static ch.tutteli.gradle.plugins.test.Asserts.assertContainsRegex
 import static org.junit.jupiter.api.Assertions.*
+import static org.junit.jupiter.api.Assumptions.assumeFalse
+import static org.junit.jupiter.api.Assumptions.assumeFalse
 
 @ExtendWith(SettingsExtension)
 class PublishPluginIntTest {
@@ -29,14 +32,14 @@ class PublishPluginIntTest {
 
     @Test
     void smokeTestJava(SettingsExtensionObject settingsSetup) throws IOException {
-        //arrange
         def version = '1.0.0'
         checkSmokeTestJava("smoke1", settingsSetup, version, null)
     }
 
     @Test
     void smokeTestJava_gradle6x(SettingsExtensionObject settingsSetup) throws IOException {
-        //arrange
+        def javaVersion = JavaVersion.toVersion(System.getProperty("java.version"))
+        assumeFalse(javaVersion >= JavaVersion.VERSION_15)
         def version = '1.0.0'
         checkSmokeTestJava("smoke1", settingsSetup, version, "6.9.4")
     }
@@ -266,6 +269,8 @@ class PublishPluginIntTest {
 
     @Test
     void subproject_gradle6x(SettingsExtensionObject settingsSetup) throws IOException {
+        def javaVersion = JavaVersion.toVersion(System.getProperty("java.version"))
+        assumeFalse(javaVersion >= JavaVersion.VERSION_15)
         checkSubproject(settingsSetup, "6.9.4")
     }
 
@@ -629,6 +634,8 @@ class PublishPluginIntTest {
 
     @Test
     void withKotlinMultiplatformApplied_gradle_6_x(SettingsExtensionObject settingsSetup) throws IOException {
+        def javaVersion = JavaVersion.toVersion(System.getProperty("java.version"))
+        assumeFalse(javaVersion >= JavaVersion.VERSION_15)
         checkKotlinMultiplatform('mpp-gradle-6.9.4', settingsSetup, false, KOTLIN_VERSION, "6.9.4")
     }
 

--- a/tutteli-gradle-spek/src/test/groovy/ch/tutteli/gradle/plugins/spek/SpekPluginIntTest.groovy
+++ b/tutteli-gradle-spek/src/test/groovy/ch/tutteli/gradle/plugins/spek/SpekPluginIntTest.groovy
@@ -2,6 +2,7 @@ package ch.tutteli.gradle.plugins.spek
 
 import ch.tutteli.gradle.plugins.test.SettingsExtension
 import ch.tutteli.gradle.plugins.test.SettingsExtensionObject
+import org.gradle.api.JavaVersion
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
@@ -12,6 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource
 
 
 import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assumptions.assumeFalse
 
 @ExtendWith(SettingsExtension)
 class SpekPluginIntTest {
@@ -35,8 +37,9 @@ class SpekPluginIntTest {
     }
 
     static List<Arguments> kotlinVersionAndGradle() {
+        def javaVersion = JavaVersion.toVersion(System.getProperty("java.version"))
         return ['1.3.61', '1.4.10', '1.5.21', '1.6.20', '1.7.20', '1.8.10'].collectMany { kotlinVersion ->
-            def gradleVersions = ['6.9.4', '7.6.1'] + (kotlinVersion.matches("^1\\.[7-9].*\$") ? ['8.0'] : [])
+            def gradleVersions = ((javaVersion < JavaVersion.VERSION_15) ? ['6.9.4', '7.6.1'] : ['7.6.1']) + (kotlinVersion.matches("^1\\.[7-9].*\$") ? ['8.0'] : [])
             gradleVersions.collect { gradleVersion ->
                 Arguments.of(kotlinVersion, gradleVersion)
             }


### PR DESCRIPTION
if one wants to use java toolchain and the module-info plugin at the same time, then one currently runs into an error because we set the source/targetCompatibility at the project level rather than configuring JavaCompile. 
This PR fixes this + enables jdk17 again and uses toolchain itself 