### PR TITLE
reproducible builds

### DIFF
--- a/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/AugmentManifestInJarTask.kt
+++ b/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/AugmentManifestInJarTask.kt
@@ -35,7 +35,6 @@ abstract class AugmentManifestInJarTask : DefaultTask() {
 
                         "Implementation-Version" to project.version,
                         "Implementation-URL" to "https://$repoUrl",
-                        "Build-Time" to ZonedDateTime.now().format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
                     ) + getVendorIfAvailable(extension) + getImplementationKotlinVersionIfAvailable(project)
                 )
                 listOf("LICENSE.txt", "LICENSE", "LICENSE.md", "LICENSE.rst").forEach { fileName ->

--- a/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/PublishPlugin.kt
+++ b/tutteli-gradle-publish/src/main/kotlin/ch.tutteli.gradle.plugins.publish/PublishPlugin.kt
@@ -6,6 +6,7 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.signing.SigningExtension
@@ -90,6 +91,15 @@ class PublishPlugin : Plugin<Project> {
                         publication.artifact(javadocJar)
                     }
                 }
+            }
+
+            tasks.withType<AbstractArchiveTask>().configureEach {
+                // Ensure builds are reproducible, see https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
+                // as well as https://github.com/gradle/gradle/issues/10900
+                isPreserveFileTimestamps = false
+                isReproducibleFileOrder = true
+                dirMode = "775".toInt(8)
+                fileMode = "664".toInt(8)
             }
         }
     }

--- a/tutteli-gradle-publish/src/test/groovy/ch/tutteli/gradle/plugins/publish/PublishPluginIntTest.groovy
+++ b/tutteli-gradle-publish/src/test/groovy/ch/tutteli/gradle/plugins/publish/PublishPluginIntTest.groovy
@@ -997,7 +997,6 @@ class PublishPluginIntTest {
         zipFile.withCloseable {
             def manifest = zipFile.getInputStream(findInZipFile(zipFile, 'META-INF/MANIFEST.MF')).text
             assertManifest(manifest, ': ', projectName, jarName, version, repoUrl, vendor, kotlinVersion)
-            assertTrue(manifest.contains("Build-Time: ${new Date().format('yyyy-MM-dd\'T\'HH:mm:ss.SSSZZ').substring(0, 10)}"), "manifest build time was not ${new Date().format('yyyy-MM-dd\'T\'HH:mm:ss.SSSZZ').substring(0, 10)}\n${manifest}")
             assertInZipFile(zipFile, 'LICENSE.txt')
         }
     }


### PR DESCRIPTION
remove Build-Time from Manifest

for to reasons:
1. we wrongly add it now already during jar creation
which means we invalidate the incremental build
2. to have reproducible builds