### PR TITLE
use lazy withType<T>().configureEach{} instead of eager withType<T>{}

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,7 +111,7 @@ subprojects {
         }
     }
 
-    tasks.withType<JavaCompile> {
+    tasks.withType<JavaCompile>().configureEach {
         sourceCompatibility = JavaVersion.VERSION_1_8.toString()
         targetCompatibility = JavaVersion.VERSION_1_8.toString()
     }
@@ -132,7 +132,7 @@ configure(pluginProjects) {
         reports.html.required.set(true)
     }
 
-    tasks.withType<Test> {
+    tasks.withType<Test>().configureEach {
         reports {
             html.outputLocation.set(file("${buildDir}/reports/junit"))
         }

--- a/tutteli-gradle-dokka/src/main/kotlin/ch.tutteli.gradle.plugins.dokka/DokkaPlugin.kt
+++ b/tutteli-gradle-dokka/src/main/kotlin/ch.tutteli.gradle.plugins.dokka/DokkaPlugin.kt
@@ -47,7 +47,7 @@ open class DokkaPlugin : Plugin<Project> {
         }
 
         if (docsDir != null) {
-            project.tasks.withType<AbstractDokkaTask> {
+            project.tasks.withType<AbstractDokkaTask>().configureEach {
                 try {
                     outputDirectory.set(docsDir)
                 } catch (e: NoSuchMethodError) {
@@ -63,7 +63,7 @@ open class DokkaPlugin : Plugin<Project> {
         }
 
         // we want to configure DokkaTask as well as DokkaPartialTask
-        project.tasks.withType<AbstractDokkaLeafTask> {
+        project.tasks.withType<AbstractDokkaLeafTask>().configureEach {
 
             dokkaSourceSets.configureEach {
                 val sourceSet = this

--- a/tutteli-gradle-junitjacoco/build.gradle.kts
+++ b/tutteli-gradle-junitjacoco/build.gradle.kts
@@ -35,7 +35,7 @@ val generateDependencyVersions = tasks.register("generateHardCodedDependencies")
         )
     }
 }
-tasks.withType<KotlinCompile>{
+tasks.withType<KotlinCompile>().configureEach {
     dependsOn(generateDependencyVersions)
 }
 afterEvaluate {

--- a/tutteli-gradle-junitjacoco/src/main/kotlin/ch/tutteli/gradle/plugins/junitjacoco/JunitJacocoPlugin.kt
+++ b/tutteli-gradle-junitjacoco/src/main/kotlin/ch/tutteli/gradle/plugins/junitjacoco/JunitJacocoPlugin.kt
@@ -15,6 +15,7 @@ import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.withType
 import java.io.File
 
 class JunitJacocoPlugin : Plugin<Project> {
@@ -26,7 +27,7 @@ class JunitJacocoPlugin : Plugin<Project> {
 
         val extension = project.extensions.create<JunitJacocoPluginExtension>(EXTENSION_NAME, project)
 
-        project.tasks.withType(Test::class.java) {
+        project.tasks.withType<Test>().configureEach {
             useJUnitPlatform()
             reports.junitXml.required.set(false)
         }
@@ -77,7 +78,7 @@ class JunitJacocoPlugin : Plugin<Project> {
 
     private fun configureTestTasks(project: Project, extension: JunitJacocoPluginExtension) {
 
-        project.tasks.withType(AbstractTestTask::class.java) {
+        project.tasks.withType<AbstractTestTask>().configureEach {
             testLogging {
                 events(
                     TestLogEvent.FAILED,
@@ -112,7 +113,10 @@ class JunitJacocoPlugin : Plugin<Project> {
             })
         }
         project.afterEvaluate {
-            project.tasks.withType(AbstractTestTask::class.java).forEach { testTask ->
+            // TODO 5.0.0 check if really still needed (maybe fixed in newer gradle versions) and if so, then find a
+            // way that we can still use configureEach instead of all in order that we can use configuration-cache
+            project.tasks.withType<AbstractTestTask>().all {
+                val testTask = this
                 if (testTask.doesNotFailIfFailedBefore) {
                     testTask.finalizedBy(failIfTestFailedLastTimeTask(project, testTask))
                 }


### PR DESCRIPTION
with the exception of the fai-test-if-last-time-failed tasks