### PR TITLE
own dokka javadoc jar per platform

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -17,7 +17,8 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.java_version }}
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2.9.0
       - name: build
         env:
           JAVA_VERSION: ${{ matrix.java_version }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,7 +17,8 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.java_version }}
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2.9.0
       - name: build
         env:
           JAVA_VERSION: ${{ matrix.java_version }}

--- a/README.md
+++ b/README.md
@@ -18,39 +18,29 @@ if you find a bug or need some help.
 
 The following sections give brief information what the different plugins offer.
 
-# ch.tutteli.gradle.plugins.project.utils [🔗](https://plugins.gradle.org/plugin/ch.tutteli.gradle.plugins.project.utils/4.10.2)
--> will most likely be removed with 5.0.0
-This plugin adds utility functions to `Project` 
-
-Currently, it provides the following functions:
-- `prefixedProject(name)` which is a shortcut for `project("${rootProject.name}-$name")`.
-   You find an example in the [build.gradle of the spek plugin](https://github.com/robstoll/tutteli-gradle-plugins/tree/v4.10.2/tutteli-gradle-spek/build.gradle#L20).
-- `createTestJarTask` creates a task named `testJar` which creates a jar containing your test binaries
-- `createTestSourcesJarTask` creates a task named `testSourcesJar` which creates a jar containing your test sources
-
 # ch.tutteli.gradle.plugins.dokka [🔗](https://plugins.gradle.org/plugin/ch.tutteli.dokka/4.10.2)
 
-Applies the [dokka-plugin](https://github.com/Kotlin/dokka) and creates a `javadocJar` task which can be used for publishing.
-Moreover, it defines a `sourceLink` per `dokkaSourceSet`. 
+Applies the [dokka-plugin](https://github.com/Kotlin/dokka) and defines a `sourceLink` per `dokkaSourceSet`.
 If the project version follows the pattern x.y.z, then an `externalDocumentationLink` per `dokkaSourceSet` is defined in addition.
 The url used for the `sourceLink` and the `externalDocumentationLink` is based on a given githubUser.
+Last but not least, it automatically configures dokka to look in test folder for *Samples.kt files for samples linked
+in KDoc.
 
 # ch.tutteli.gradle.plugins.junitjacoco [🔗](https://plugins.gradle.org/plugin/ch.tutteli.junitjacoco/4.10.2)
 Applies the [junit-platform-gradle-plugin](https://junit.org/junit5/docs/current/user-guide/#running-tests-build-gradle)
 as well as the [jacoco-plugin](https://docs.gradle.org/current/userguide/jacoco_plugin.html)
 and applies some default configuration.
 
-This plugin does not set up a junit engine and you need to define it yourself. 
+This plugin does not set up a junit engine and you need to define it yourself.
 Have a look at [build.gradle](https://github.com/robstoll/tutteli-gradle-plugins/tree/v4.10.2/build.gradle#L61)
 for an example.
-In case you should use Spek as your engine, then you might want to have a look at the `spek` plugin below.
 
 # ch.tutteli.gradle.plugins.kotlin.module.info [🔗](https://plugins.gradle.org/plugin/ch.tutteli.gradle.plugins.kotlin.module.info/4.10.2)
 
 Intended to be used in a kotlin project where either module-info.java is the single java source file or where >= jdk 11 is used.
-It sets up compileJava accordingly and configures JavaCompile tasks to use jdk 11 for `sourceCompatibility`/`targetCompatibility` if not already set or higher. 
+It sets up compileJava accordingly and configures JavaCompile tasks to use jdk 11 for `sourceCompatibility`/`targetCompatibility` if not already set or higher.
 
-Per default, it reads the module name (which is used for `--patch-module`) from the defined module-info.java. 
+Per default, it reads the module name (which is used for `--patch-module`) from the defined module-info.java.
 You can speed up this process (in case you have many java files) by defining `moduleName` on `project.extra`.
 
 # ch.tutteli.gradle.plugins.kotlin.utils [🔗](https://plugins.gradle.org/plugin/ch.tutteli.gradle.plugins.kotlin.utils/4.10.2)
@@ -60,14 +50,24 @@ Provides some utility functions to declare dependencies on kotlin projects, to c
 Requires that `kotlinutils.kotlinVersion` (property on the extension) is configured.
 
 Following a list of functions it supports:
-- declare dependencies on libs: `kotlinStdlib()`, `kotlinStdlibJs()`, `kotlinStdlibCommon()`, `kotlinReflect()`, `kotlinTestJs()`, `kotlinTestCommon()`, , `kotlinTestAnotationsCommon()`  
+- declare dependencies on libs: `kotlinStdlib()`, `kotlinStdlibJs()`, `kotlinStdlibCommon()`, `kotlinReflect()`, `kotlinTestJs()`, `kotlinTestCommon()`, , `kotlinTestAnotationsCommon()`
 - exclude dependencies: `excludeKotlin`, `excludeKbox`, `excludeAtriumVerbs` (see example)
 - configure projects: `configureCommonProjects`, `configureJsProjects`, `configureJvmProjects`
-- `getCommonProjects()`, `getJsProjects()`, `getJvmProjects()`, `getProjectNameWithoutSuffix(project)`   
+- `getCommonProjects()`, `getJsProjects()`, `getJvmProjects()`, `getProjectNameWithoutSuffix(project)`
 
 Moreover, it turns warnings into errors if one of the env variables `CI` or `WARN_AS_ERROR` is set to `true`.
 
 You find an example in [KotlinUtilsPluginIntTest](https://github.com/robstoll/tutteli-gradle-plugins/tree/main/tutteli-gradle-kotlin-utils/src/test/groovy/ch/tutteli/gradle/kotlin/KotlinUtilsPluginIntTest.groovy#L45).
+
+# ch.tutteli.gradle.plugins.project.utils [🔗](https://plugins.gradle.org/plugin/ch.tutteli.gradle.plugins.project.utils/4.10.2)
+-> will most likely be removed with 5.0.0
+This plugin adds utility functions to `Project` 
+
+Currently, it provides the following functions:
+- `prefixedProject(name)` which is a shortcut for `project("${rootProject.name}-$name")`.
+   You find an example in the [build.gradle of the spek plugin](https://github.com/robstoll/tutteli-gradle-plugins/tree/v4.10.2/tutteli-gradle-spek/build.gradle#L20).
+- `createTestJarTask` creates a task named `testJar` which creates a jar containing your test binaries
+- `createTestSourcesJarTask` creates a task named `testSourcesJar` which creates a jar containing your test sources
 
 # ch.tutteli.gradle.plugins.publish [🔗](https://plugins.gradle.org/plugin/ch.tutteli.gradle.plugins.publish/4.10.2)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ val mavenModelVersion by extra("3.8.7")
 val jacocoToolVersion by extra("0.8.8")
 
 buildscript {
-    val version = "4.10.2"
+    val version = "4.11.0-SNAPSHOT"
     val previousVersion = "4.10.0"
 
     rootProject.version = version

--- a/tutteli-gradle-dokka/src/main/kotlin/ch.tutteli.gradle.plugins.dokka/DokkaPluginExtension.kt
+++ b/tutteli-gradle-dokka/src/main/kotlin/ch.tutteli.gradle.plugins.dokka/DokkaPluginExtension.kt
@@ -3,7 +3,6 @@ package ch.tutteli.gradle.plugins.dokka
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.findByType
-import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.property
 
 open class DokkaPluginExtension(project: Project) {
@@ -13,7 +12,13 @@ open class DokkaPluginExtension(project: Project) {
     /**
      * true: kdoc included in docs/kdoc without versioning vs false: gh-pages branch with version/kdoc/
      */
+    @Deprecated("will be removed with 5.0.0 at the latest", ReplaceWith("this.writeToDocs"))
     val modeSimple: Property<Boolean> = project.objects.property()
+
+    /**
+     * true: kdoc included in docs/kdoc without versioning vs false: gh-pages branch with version/kdoc/
+     */
+    val writeToDocs: Property<Boolean> = project.objects.property()
 
     init {
         if (isTutteliProject(project) || isTutteliProject(project.rootProject)) {
@@ -29,6 +34,7 @@ open class DokkaPluginExtension(project: Project) {
             takeOverValueFromRoot(rootExtension.githubUser, githubUser)
         }
         modeSimple.convention(true)
+        writeToDocs.convention(true)
     }
 
     private fun <T> takeOverValueFromRoot(rootProperty: Property<T>, property: Property<T>) {

--- a/tutteli-gradle-dokka/src/test/groovy/ch/tutteli/gradle/plugins/dokka/DokkaPluginSmokeTest.groovy
+++ b/tutteli-gradle-dokka/src/test/groovy/ch/tutteli/gradle/plugins/dokka/DokkaPluginSmokeTest.groovy
@@ -41,10 +41,6 @@ class DokkaPluginSmokeTest {
         assertEquals(projectName, dokkaTask.moduleName.get())
         assertEquals("$project.projectDir${s}docs${s}kdoc".toString(), dokkaTask.outputDirectory.get().asFile.absolutePath)
 
-        Jar javadocTask = project.tasks.getByName(DokkaPlugin.TASK_NAME_JAVADOC) as Jar
-        assertNotNull(javadocTask, DokkaPlugin.TASK_NAME_JAVADOC)
-        assertEquals('javadoc', javadocTask.archiveClassifier.get())
-
         GradleSourceLinkBuilder sourceLink = getSingleMainSourceLink(dokkaTask)
         assertEquals("$project.projectDir${s}src${s}main${s}kotlin".toString(), sourceLink.localDirectory.get().absolutePath)
         assertEquals('#L', sourceLink.remoteLineSuffix.get())
@@ -69,7 +65,7 @@ class DokkaPluginSmokeTest {
         project.plugins.apply(DokkaPlugin)
         def extension = getExtension(project)
         extension.githubUser.set(githubUser)
-        extension.getModeSimple().set(false)
+        extension.getWriteToDocs().set(false)
         project.evaluate()
 
         //assert
@@ -77,9 +73,41 @@ class DokkaPluginSmokeTest {
         assertEquals(projectName, dokkaTask.moduleName.get())
         assertEquals("${project.projectDir.toPath().resolve("..").normalize()}${s}$projectName-gh-pages${s}$version${s}kdoc".toString(), dokkaTask.outputDirectory.get().asFile.absolutePath)
 
-        Jar javadocTask = project.tasks.getByName(DokkaPlugin.TASK_NAME_JAVADOC) as Jar
-        assertNotNull(javadocTask, DokkaPlugin.TASK_NAME_JAVADOC)
-        assertEquals('javadoc', javadocTask.archiveClassifier.get())
+        GradleSourceLinkBuilder sourceLink = getSingleMainSourceLink(dokkaTask)
+        assertEquals("$project.projectDir${s}src${s}main${s}kotlin".toString(), sourceLink.localDirectory.get().absolutePath)
+        assertEquals('#L', sourceLink.remoteLineSuffix.get())
+
+        GradleExternalDocumentationLinkBuilder externalDocLInk = getSingleMainExternalDocumentationLink(dokkaTask)
+        assertEquals("https://${githubUser}.github.io/$projectName/$version/kdoc/".toString(), externalDocLInk.url.get().toString())
+
+        project.evaluate()
+        assertEquals("https://github.com/$githubUser/$projectName/tree/v$version/src/main/kotlin".toString(), sourceLink.remoteUrl.get().toString())
+    }
+
+    //TODO 5.0.0 remove
+    @Test
+    void smokeTestGhPages_viaModeSimple_ReleaseVersion() {
+        //arrange
+        def githubUser = 'robstoll'
+        def projectName = 'atrium'
+        def version = '0.6.0'
+        Project project = ProjectBuilder.builder()
+            .withName(projectName)
+            .build()
+        Files.createDirectories(project.projectDir.toPath().resolve("src/main/kotlin"))
+        //act
+        project.version = version
+        project.plugins.apply('org.jetbrains.kotlin.jvm')
+        project.plugins.apply(DokkaPlugin)
+        def extension = getExtension(project)
+        extension.githubUser.set(githubUser)
+        extension.getModeSimple().set(false)
+        project.evaluate()
+
+        //assert
+        DokkaTask dokkaTask = getDokkaTask(project)
+        assertEquals(projectName, dokkaTask.moduleName.get())
+        assertEquals("${project.projectDir.toPath().resolve("..").normalize()}${s}$projectName-gh-pages${s}$version${s}kdoc".toString(), dokkaTask.outputDirectory.get().asFile.absolutePath)
 
         GradleSourceLinkBuilder sourceLink = getSingleMainSourceLink(dokkaTask)
         assertEquals("$project.projectDir${s}src${s}main${s}kotlin".toString(), sourceLink.localDirectory.get().absolutePath)
@@ -109,7 +137,7 @@ class DokkaPluginSmokeTest {
         project.plugins.apply(DokkaPlugin)
         def extension = getExtension(project)
         extension.githubUser.set(githubUser)
-        extension.getModeSimple().set(false)
+        extension.getWriteToDocs().set(false)
         project.evaluate()
 
         //assert
@@ -117,9 +145,41 @@ class DokkaPluginSmokeTest {
         assertEquals(projectName, dokkaTask.moduleName.get())
         assertEquals("${project.projectDir.toPath().resolve("..").normalize()}${s}$projectName-gh-pages${s}$version${s}kdoc".toString(), dokkaTask.outputDirectory.get().asFile.absolutePath)
 
-        Jar javadocTask = project.tasks.getByName(DokkaPlugin.TASK_NAME_JAVADOC) as Jar
-        assertNotNull(javadocTask, DokkaPlugin.TASK_NAME_JAVADOC)
-        assertEquals('javadoc', javadocTask.archiveClassifier.get())
+        GradleSourceLinkBuilder sourceLink = getSingleMainSourceLink(dokkaTask)
+        assertEquals("$project.projectDir${s}src${s}main${s}kotlin".toString(), sourceLink.localDirectory.get().absolutePath)
+        assertEquals('#L', sourceLink.remoteLineSuffix.get())
+
+        assertHasNoExternalDocumentationLinksDefined(dokkaTask)
+
+        project.evaluate()
+        assertEquals("https://github.com/$githubUser/$projectName/tree/v$version/src/main/kotlin".toString(), sourceLink.remoteUrl.get().toString())
+    }
+
+    // TODO remove with 5.0.0
+    @Test
+    void smokeTestGhPages_viaModeSimple_RcVersion() {
+        def version = '0.6.0-RC.1'
+        //arrange
+        def githubUser = 'robstoll'
+        def projectName = 'atrium'
+
+        Project project = ProjectBuilder.builder()
+            .withName(projectName)
+            .build()
+        Files.createDirectories(project.projectDir.toPath().resolve("src/main/kotlin"))
+        //act
+        project.version = version
+        project.plugins.apply('org.jetbrains.kotlin.jvm')
+        project.plugins.apply(DokkaPlugin)
+        def extension = getExtension(project)
+        extension.githubUser.set(githubUser)
+        extension.getModeSimple().set(false)
+        project.evaluate()
+
+        //assert
+        DokkaTask dokkaTask = getDokkaTask(project)
+        assertEquals(projectName, dokkaTask.moduleName.get())
+        assertEquals("${project.projectDir.toPath().resolve("..").normalize()}${s}$projectName-gh-pages${s}$version${s}kdoc".toString(), dokkaTask.outputDirectory.get().asFile.absolutePath)
 
         GradleSourceLinkBuilder sourceLink = getSingleMainSourceLink(dokkaTask)
         assertEquals("$project.projectDir${s}src${s}main${s}kotlin".toString(), sourceLink.localDirectory.get().absolutePath)
@@ -148,7 +208,7 @@ class DokkaPluginSmokeTest {
         project.plugins.apply(DokkaPlugin)
         def extension = getExtension(project)
         extension.githubUser.set(githubUser)
-        extension.getModeSimple().set(false)
+        extension.getWriteToDocs().set(false)
         project.evaluate()
 
         //assert
@@ -156,9 +216,42 @@ class DokkaPluginSmokeTest {
         assertEquals(projectName, dokkaTask.moduleName.get())
         assertEquals("${project.projectDir.toPath().resolve("..").normalize()}${s}$projectName-gh-pages${s}$version${s}kdoc".toString(), dokkaTask.outputDirectory.get().asFile.absolutePath)
 
-        Jar javadocTask = project.tasks.getByName(DokkaPlugin.TASK_NAME_JAVADOC) as Jar
-        assertNotNull(javadocTask, DokkaPlugin.TASK_NAME_JAVADOC)
-        assertEquals('javadoc', javadocTask.archiveClassifier.get())
+        GradleSourceLinkBuilder sourceLink = getSingleMainSourceLink(dokkaTask)
+        assertEquals("$project.projectDir${s}src${s}main${s}kotlin".toString(), sourceLink.localDirectory.get().absolutePath)
+        assertEquals('#L', sourceLink.remoteLineSuffix.get())
+
+        assertHasNoExternalDocumentationLinksDefined(dokkaTask)
+
+        project.evaluate()
+        assertEquals("https://github.com/$githubUser/$projectName/tree/main/src/main/kotlin".toString(), sourceLink.remoteUrl.get().toString())
+    }
+
+
+
+    @Test
+    void smokeTestGhPages_viaModeSimple_SnapshotVersion() {
+        def version = '0.6.0-SNAPSHOT'
+        //arrange
+        def githubUser = 'robstoll'
+        def projectName = 'atrium'
+
+        Project project = ProjectBuilder.builder()
+            .withName(projectName)
+            .build()
+        Files.createDirectories(project.projectDir.toPath().resolve("src/main/kotlin"))
+        //act
+        project.version = version
+        project.plugins.apply('org.jetbrains.kotlin.jvm')
+        project.plugins.apply(DokkaPlugin)
+        def extension = getExtension(project)
+        extension.githubUser.set(githubUser)
+        extension.getModeSimple().set(false)
+        project.evaluate()
+
+        //assert
+        DokkaTask dokkaTask = getDokkaTask(project)
+        assertEquals(projectName, dokkaTask.moduleName.get())
+        assertEquals("${project.projectDir.toPath().resolve("..").normalize()}${s}$projectName-gh-pages${s}$version${s}kdoc".toString(), dokkaTask.outputDirectory.get().asFile.absolutePath)
 
         GradleSourceLinkBuilder sourceLink = getSingleMainSourceLink(dokkaTask)
         assertEquals("$project.projectDir${s}src${s}main${s}kotlin".toString(), sourceLink.localDirectory.get().absolutePath)

--- a/tutteli-gradle-publish/build.gradle.kts
+++ b/tutteli-gradle-publish/build.gradle.kts
@@ -13,9 +13,14 @@ repositories {
 
 val mavenModelVersion: String by rootProject.extra
 val kotlinVersion: String by rootProject.extra
+val dokkaVersion: String by rootProject.extra
 
 dependencies {
     implementation("org.apache.maven:maven-model:$mavenModelVersion")
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+    compileOnly("org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"){
+        exclude("com.jetbrains.kotlin")
+    }
 }

--- a/tutteli-gradle-publish/src/test/groovy/ch/tutteli/gradle/plugins/publish/PublishPluginSmokeTest.groovy
+++ b/tutteli-gradle-publish/src/test/groovy/ch/tutteli/gradle/plugins/publish/PublishPluginSmokeTest.groovy
@@ -179,7 +179,6 @@ class PublishPluginSmokeTest {
 
     private static void assertExtensionAndTaskDefined(Project project, String jarTaskName = "jar") {
         project.extensions.getByName(PublishPlugin.EXTENSION_NAME)
-        Asserts.assertTaskExists(project, PublishPlugin.TASK_NAME_PREFIX_AUGMENT_MANIFEST_IN_JAR + jarTaskName)
         Asserts.assertTaskExists(project, PublishPlugin.TASK_NAME_VALIDATE_PUBLISH)
     }
 

--- a/tutteli-gradle-spek/src/main/groovy/ch/tutteli/gradle/plugins/spek/SpekPlugin.groovy
+++ b/tutteli-gradle-spek/src/main/groovy/ch/tutteli/gradle/plugins/spek/SpekPlugin.groovy
@@ -29,7 +29,7 @@ class SpekPlugin implements Plugin<Project> {
                 throw new IllegalStateException("spek 1 is no longer supported by this plugin.")
             }
 
-            if (project.plugins.findPlugin('org.jetbrains.kotlin.multiplatform') != null) {
+            if (project.plugins.hasPlugin('org.jetbrains.kotlin.multiplatform')) {
                 configureForMpp(project, spekVersion)
             } else {
                 configureForJvm(project, spekVersion)


### PR DESCRIPTION
This way we don't have an overlapping when signing the javadoc jar ( before

moreover:
- create it in the publish plugin and not in the dokka plugin
- configure AbstractArchiveTask not in project.afterEvaluate
- same same for jar augmentation + switch back to doFirst again instead of registering an own task as doing so hinders us in using configureEach (had to use all due to this)