### PR TITLE
don't apply java in jacoco plugin and workaround MPP issues

### DIFF
--- a/tutteli-gradle-junitjacoco/src/test/groovy/ch/tutteli/gradle/plugins/junitjacoco/JunitJacocoPluginSmokeTest.groovy
+++ b/tutteli-gradle-junitjacoco/src/test/groovy/ch/tutteli/gradle/plugins/junitjacoco/JunitJacocoPluginSmokeTest.groovy
@@ -1,7 +1,7 @@
 package ch.tutteli.gradle.plugins.junitjacoco
 
-import ch.tutteli.gradle.plugins.junitjacoco.JunitJacocoPlugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.junit.jupiter.api.Test
@@ -24,8 +24,18 @@ class JunitJacocoPluginSmokeTest {
         assertTrue(jacocoReport.reports.xml.required.get(), 'jacoco xml report should be enabled by default')
         assertFalse(jacocoReport.reports.csv.required.get(), 'jacoco csv report should be disabled by default')
         assertFalse(jacocoReport.reports.html.required.get(), 'jacoco html report should be disabled by default')
+    }
+
+    @Test
+    void smokeTestWithJavaApplied(){
+        //arrange
+        Project project = ProjectBuilder.builder().build()
+        //act
+        project.plugins.apply(JavaPlugin)
+        project.plugins.apply(JunitJacocoPlugin)
 
         project.evaluate()
         assertFalse(project.test.reports.junitXml.required.get(), "junitXml report should be disabled per default")
+
     }
 }

--- a/tutteli-gradle-junitjacoco/src/test/groovy/ch/tutteli/gradle/plugins/junitjacoco/JunitJacocoPluginTest.groovy
+++ b/tutteli-gradle-junitjacoco/src/test/groovy/ch/tutteli/gradle/plugins/junitjacoco/JunitJacocoPluginTest.groovy
@@ -1,6 +1,6 @@
 package ch.tutteli.gradle.plugins.junitjacoco
 
-import ch.tutteli.gradle.plugins.junitjacoco.JunitJacocoPlugin
+
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
create an own jacocoTestTask (no longer automatically created as jacoco plugin expects Java plugin to be there).